### PR TITLE
no need to warn about build result not being JSON

### DIFF
--- a/koji_containerbuild/cli.py
+++ b/koji_containerbuild/cli.py
@@ -40,8 +40,9 @@ def print_task_result(task_id, result, weburl):
         result["koji_builds"] = ["%s/buildinfo?buildID=%s" % (weburl, build_id)
                                  for build_id in result.get("koji_builds", [])]
         result = json.dumps(result, sort_keys=True, indent=4)
-    except:
-        print "Unable to convert result output to JSON."
+    except ValueError:
+        # Unable to convert result output to JSON
+        pass
 
     print "Task Result (%s):" % task_id
     print result


### PR DESCRIPTION
There is no need to warn if the build result cannot be parsed as JSON. This can happen if the CLI package is installed but the Koji builder has an older version of the koji-containerbuild-builder plugin.