### PR TITLE
Supply koji_task_id to create_build()

### DIFF
--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -377,6 +377,7 @@ class CreateContainerTask(BaseTaskHandler):
             'architecture': arch,
             'yum_repourls': yum_repourls,
             'scratch': scratch,
+            'koji_task_id': self.id,
         }
         if branch:
             create_build_args['git_branch'] = branch


### PR DESCRIPTION
This allows osbs-client to set a label on the BuildConfig which we can query later.

This parameter will be ignored with older osbs-client versions.