### PR TITLE
make streamed logs line-buffered

### DIFF
--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -322,6 +322,7 @@ class CreateContainerTask(BaseTaskHandler):
         try:
             for line in build_logs:
                 outfile.write("%s\n" % line)
+                outfile.flush()
         except Exception, error:
             msg = "Exception (%s) while reading build logs: %s" % (type(error),
                                                                    error)


### PR DESCRIPTION
Currently, developers cannot follow build logs line-by-line because the incremental build log is only written to disk when the write buffer is full.

This commit flushes the output after each line.