### PR TITLE
Drop support for release parameter

### DIFF
--- a/koji_containerbuild/cli.py
+++ b/koji_containerbuild/cli.py
@@ -120,7 +120,7 @@ def handle_container_build(options, session, args):
             parser.error(_("Destination tag %s is locked" % dest_tag['name']))
     source = args[1]
     opts = {}
-    for key in ('scratch', 'epoch', 'yum_repourls', 'git_branch', 'release'):
+    for key in ('scratch', 'epoch', 'yum_repourls', 'git_branch'):
         val = getattr(build_opts, key)
         if val is not None:
             opts[key] = val


### PR DESCRIPTION
Verified that `buildContainer` does not complain about accepting "release" parameter, but it's completely ignored and not forwarded to `createContainer` task.