### PR TITLE
Merge buildContainer and createContainer tasks

### DIFF
--- a/docs/build-process.md
+++ b/docs/build-process.md
@@ -1,14 +1,7 @@
 1. User calls `buildContainer` XMLRPC call - e.g. by `container-build` command of `rpkg`.
 2. Hub XMLRPC handler `buildContainer` creates `buildContainer` method.
 3. Builder method `buildContainer`:
-    1. [creates a build object](https://github.com/release-engineering/koji-containerbuild/blob/master/koji_containerbuild/plugins/builder_containerbuild.py#L642),
-    2. subtask `createContainer`
-    3. waits for `createcontainer` to finish
-4. Builder method `createcontainer`:
-    1. [creates build in OSBS](https://github.com/release-engineering/koji-containerbuild/blob/master/koji_containerbuild/plugins/builder_containerbuild.py#L333)
-    2. Watches logs and sends them to hub to save.
-    3. When build finishes downloads image tarball from the OSBS
-5. Builder method `buildContainer`:
-    1. Verifies list of rpms against database
-    2. [Saves tarball as build artefact](https://github.com/release-engineering/koji-containerbuild/blob/master/koji_containerbuild/plugins/builder_containerbuild.py#L672)
-    3. Creates subtask `tagBuild` to tag the build
+    1. Checks that target and SCM are correct
+    2. Checks that build with given NVR doesn't exist (unless its a scratch or autorelease task)
+    3. For each architecture [creates build in OSBS](https://github.com/release-engineering/koji-containerbuild/blob/master/koji_containerbuild/plugins/builder_containerbuild.py#L413)
+    4. Watches logs and sends them to hub to save.

--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -263,9 +263,9 @@ class LabelsWrapper(object):
 
 
 class BuildContainerTask(BaseTaskHandler):
+    # Start builds via osbs for each arch (this might change soon)
     Methods = ['buildContainer']
-    # We mostly just wait on other tasks. Same value as for regular 'build'
-    # method.
+    # Same value as for regular 'build' method.
     _taskWeight = 2.0
 
     def __init__(self, id, method, params, session, options, workdir=None):

--- a/tests/test_kcb.py
+++ b/tests/test_kcb.py
@@ -5,7 +5,6 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
 
-import sys
 from flexmock import flexmock
 import pytest
 import osbs
@@ -24,17 +23,17 @@ builder_containerbuild.kojid = KojidMock()
 class TestBuilder(object):
     @pytest.mark.parametrize("resdir", ['test', 'test2'])
     def test_resultdir(self, resdir):
-        cct = builder_containerbuild.CreateContainerTask(id=1, method='createContainer', params='params', session='session', options='options', workdir=resdir)
+        cct = builder_containerbuild.BuildContainerTask(id=1, method='buildContainer', params='params', session='session', options='options', workdir=resdir)
         assert cct.resultdir() == '%s/osbslogs' % resdir
 
     def test_osbs(self):
-        cct = builder_containerbuild.CreateContainerTask(id=1, method='createContainer', params='params', session='session', options='options', workdir='workdir')
+        cct = builder_containerbuild.BuildContainerTask(id=1, method='buildContainer', params='params', session='session', options='options', workdir='workdir')
         assert type(cct.osbs()) is osbs.api.OSBS
 
     @pytest.mark.parametrize("repos", [{'repo1': 'test1'}, {'repo2': 'test2'}])
     def test_get_repositories(self, repos):
         response = flexmock(get_repositories=lambda: repos)
-        cct = builder_containerbuild.CreateContainerTask(id=1, method='createContainer', params='params', session='session', options='options', workdir='workdir')
+        cct = builder_containerbuild.BuildContainerTask(id=1, method='buildContainer', params='params', session='session', options='options', workdir='workdir')
         repositories = [] 
         for repo in repos.values():
             repositories.extend(repo)


### PR DESCRIPTION
Koji now spawns one task to build a container. 

Note, that currently various arches are handled sequentially. This probably will 
change when multi-arch proposal will be defined.

Tested on a local koji, except the base images building

TODO:
 * [x] Update documentation
 * [x] Update tests