### PR TITLE
Cli arches and tests

### DIFF
--- a/koji_containerbuild/cli.py
+++ b/koji_containerbuild/cli.py
@@ -21,7 +21,6 @@
 #       Pavol Babincak <pbabinca@redhat.com>
 
 import os
-import json
 from koji import _
 from optparse import OptionParser
 
@@ -62,7 +61,7 @@ def print_task_result(task_id, result, weburl):
     print_result(result)
 
 
-def handle_container_build(options, session, args):
+def parse_arguments(options, args):
     "Build a container"
     usage = _("usage: %prog container-build [options] target <scm url or "
               "archive path>")
@@ -101,11 +100,24 @@ def handle_container_build(options, session, args):
                       help=_("Set release value"))
     parser.add_option("--koji-parent-build",
                       help=_("Overwrite parent image with image from koji build"))
-    (build_opts, args) = parser.parse_args(args)
+    build_opts, args = parser.parse_args(args)
     if len(args) != 2:
         parser.error(_("Exactly two arguments (a build target and a SCM URL "
                        "or archive file) are required"))
         assert False
+    opts = {}
+    for key in ('scratch', 'epoch', 'yum_repourls', 'release',
+                'git_branch', 'isolated', 'koji_parent_build'):
+        val = getattr(build_opts, key)
+        if val is not None:
+            opts[key] = val
+    # create the parser in this function and return it to
+    # simplify the unit test cases
+    return build_opts, args, opts, parser
+
+
+def handle_container_build(options, session, args):
+    build_opts, args, opts, parser = parse_arguments(options, args)
 
     if build_opts.isolated and build_opts.scratch:
         parser.error(_("Build cannot be both isolated and scratch"))
@@ -141,12 +153,7 @@ def handle_container_build(options, session, args):
         if dest_tag['locked'] and not build_opts.scratch:
             parser.error(_("Destination tag %s is locked" % dest_tag['name']))
     source = args[1]
-    opts = {}
-    for key in ('scratch', 'epoch', 'yum_repourls', 'git_branch', 'release', 'isolated',
-                'koji_parent_build'):
-        val = getattr(build_opts, key)
-        if val is not None:
-            opts[key] = val
+
     priority = None
     if build_opts.background:
         # relative to koji.PRIO_DEFAULT

--- a/tests/test_kcb.py
+++ b/tests/test_kcb.py
@@ -17,6 +17,7 @@ try:
     from osbs.exceptions import OsbsOrchestratorNotEnabled
 except ImportError:
     from osbs.exceptions import OsbsValidationException as OsbsOrchestratorNotEnabled
+from koji_containerbuild.cli import parse_arguments
 
 
 USE_DEFAULT_PKG_INFO = object()
@@ -413,3 +414,107 @@ class TestBuilder(object):
         with pytest.raises(koji.BuildError) as exc_info:
             task.handler(src['src'], 'target', opts=additional_args)
         assert 'already exists' in str(exc_info.value)
+
+    # split into multiple groups of five to minimize run time and complexity
+    @pytest.mark.parametrize(('scratch', 'wait', 'quiet',
+                              'noprogress'), (
+        (None, None, None, None),
+        (True, None, None, None),
+        (None, True, None, None),
+        (None, None, True, None),
+        (None, None, False, None),
+        (None, None, None, True),
+        (True, True, True, True),
+    ))
+    @pytest.mark.parametrize(('epoch', 'repo_url', 'git_branch',
+                              'channel_override', 'release'), (
+        (None, None, None, None, None),
+        ('Tuesday', None, None, None, None),
+        (None, ['http://test'], None, None, None),
+        (None, ['http://test1', 'http://test2'], None, None, None),
+        (None, None, 'http://test.git', None, None),
+        (None, None, None, 'override', None),
+        (None, None, None, None, 'test_release'),
+        ('Tuesday', ['http://test1', 'http://test2'],
+         'http://test.git', 'override', 'test_release'),
+    ))
+    @pytest.mark.parametrize(('isolated', 'koji_parent_build'), (
+        (None, None),
+        (True, None),
+        (None, 'parent_build'),
+        (True, 'parent_build'),
+    ))
+    def test_cli_args(self, tmpdir, scratch, wait, quiet, noprogress,
+                      epoch, repo_url, git_branch, channel_override, release,
+                      isolated, koji_parent_build):
+        options = flexmock(allowed_scms='pkgs.example.com:/*:no')
+        options.quiet = False
+        test_args = ['test', 'test']
+        expected_args = ['test', 'test']
+        expected_opts = {}
+
+        if scratch:
+            test_args.append('--scratch')
+            expected_opts['scratch'] = scratch
+
+        if wait:
+            test_args.append('--wait')
+        elif wait is False:
+            test_args.append('--nowait')
+
+        if quiet:
+            test_args.append('--quiet')
+
+        if noprogress:
+            test_args.append('--noprogress')
+
+        if epoch:
+            test_args.append('--epoch')
+            test_args.append(epoch)
+            expected_opts['epoch'] = epoch
+
+        if repo_url:
+            expected_opts['yum_repourls'] = []
+            for url in repo_url:
+                test_args.append('--repo-url')
+                test_args.append(url)
+                expected_opts['yum_repourls'].append(url)
+
+        if git_branch:
+            test_args.append('--git-branch')
+            test_args.append(git_branch)
+            expected_opts['git_branch'] = git_branch
+
+        if channel_override:
+            test_args.append('--channel-override')
+            test_args.append(channel_override)
+
+        if release:
+            test_args.append('--release')
+            test_args.append(release)
+            expected_opts['release'] = release
+
+        if koji_parent_build:
+            test_args.append('--koji-parent-build')
+            test_args.append(koji_parent_build)
+            expected_opts['koji_parent_build'] = koji_parent_build
+
+        if isolated:
+            test_args.append('--isolated')
+            expected_opts['isolated'] = isolated
+
+        build_opts, parsed_args, opts, _ = parse_arguments(options, test_args)
+        expected_quiet = quiet or options.quiet
+        expected_channel = channel_override or 'container'
+        assert build_opts.scratch == scratch
+        assert build_opts.wait == wait
+        assert build_opts.quiet == expected_quiet
+        assert build_opts.epoch == epoch
+        assert build_opts.noprogress == noprogress
+        assert build_opts.yum_repourls == repo_url
+        assert build_opts.git_branch == git_branch
+        assert build_opts.channel_override == expected_channel
+        assert build_opts.release == release
+
+        assert parsed_args == expected_args
+        assert opts == expected_opts


### PR DESCRIPTION
two commits to add support for the --arches argument and some tests of the CLI parser

    cli: write a test case for the arguments parser
    
    add a test case for the arguments parser. There are 9 arguments with
    binary or trinary values, so group the parametrization into two sets
    of 4 and 5 to prevent the combinations generating thousands of tests
    cases.

and

    cli: add --arches argument option
    
    --arches get passed on as arch_override