### PR TITLE
builder_containerbuild: use get_orchestrator_build_logs api

### DIFF
--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -335,13 +335,13 @@ class BuildContainerTask(BaseTaskHandler):
         log_filename = os.path.join(logs_dir, log_basename)
 
         self.logger.info("Will write follow log: %s", log_basename)
-        outfile = open(log_filename, 'w')
+        outfile = open(log_filename, 'wb')
         try:
             for line in log:
-                outfile.write("%s\n" % line)
-            outfile.flush()
+                outfile.write(("%s\n" % line).encode('utf-8'))
+                outfile.flush()
         except Exception, error:
-            msg = "Exception (%s) while reading build logs: %s" % (type(error),
+            msg = "Exception (%s) while writing build logs: %s" % (type(error),
                                                                    error)
             raise ContainerError(msg)
         finally:
@@ -356,15 +356,15 @@ class BuildContainerTask(BaseTaskHandler):
             if platform not in platform_logs:
                 prefix = 'orchestrator' if platform is None else platform
                 log_filename = os.path.join(logs_dir, "%s.log" % prefix)
-                platform_logs[platform] = open(log_filename, 'w')
+                platform_logs[platform] = open(log_filename, 'wb')
             try:
                 platform_logs[platform].write((entry.line + '\n').encode('utf-8'))
+                platform_logs[platform].flush()
             except Exception, error:
-                msg = "Exception (%s) while reading build logs: %s" % (type(error),
+                msg = "Exception (%s) while writing build logs: %s" % (type(error),
                                                                        error)
                 raise ContainerError(msg)
-        for platform, logfile in platform_logs.items():
-            logfile.flush()
+        for logfile in platform_logs.values():
             logfile.close()
             self.logger.info("%s written", logfile.name)
 

--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -281,10 +281,11 @@ class BuildContainerTask(BaseTaskHandler):
     # Same value as for regular 'build' method.
     _taskWeight = 2.0
 
-    def __init__(self, id, method, params, session, options, workdir=None):
+    def __init__(self, id, method, params, session, options, workdir=None, demux=True):
         BaseTaskHandler.__init__(self, id, method, params, session, options,
                                  workdir)
         self._osbs = None
+        self.demux = demux
 
         # Check that the kojid module was successfully imported
         assert kojid
@@ -380,7 +381,7 @@ class BuildContainerTask(BaseTaskHandler):
 
     def _write_incremental_logs(self, build_id, logs_dir):
         build_logs = None
-        if hasattr(self.osbs(), 'get_orchestrator_build_logs'):
+        if self.demux and hasattr(self.osbs(), 'get_orchestrator_build_logs'):
             self._write_demultiplexed_logs(build_id, logs_dir)
         else:
             self._write_combined_log(build_id, logs_dir)


### PR DESCRIPTION
Use the new get_orchestrator_build_logs API if available, to provide split
logs, one for orchestrator, one for each arch built.

Tested successfully in an osbs-box deployment.

Signed-off-by: Jarod Wilson <jarod@redhat.com>