### PR TITLE
Run koji-containerbuild tests in Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # ## Linux
-.*
+.cache
+.coverage
+build/
 !.gitignore
 /dist/
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 # ## Linux
 .cache
 .coverage
-build/
-!.gitignore
+/build/
 /dist/
 
 # ## Python

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: python
+sudo: "required"
+services:
+  - docker
+env:
+  matrix:
+    - OS=centos
+      OS_VERSION=6
+      PYTHON_VERSION=2
+    - OS=centos
+      OS_VERSION=7
+      PYTHON_VERSION=2
+    - OS=fedora
+      OS_VERSION=25
+      PYTHON_VERSION=2
+    - OS=fedora
+      OS_VERSION=26
+      PYTHON_VERSION=2
+    - OS=fedora
+      OS_VERSION=rawhide
+      PYTHON_VERSION=2
+script:
+ - pip install coveralls
+ - ./test.sh
+after_success: coveralls
+notifications:
+  email: false

--- a/koji-containerbuild.spec
+++ b/koji-containerbuild.spec
@@ -7,7 +7,7 @@
 
 Name:           koji-containerbuild
 Version:        0.7.4
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Koji support for building layered container images
 Group:          Applications/System
 
@@ -55,7 +55,6 @@ Requires:   koji-containerbuild
 Requires:   osbs-client
 Requires:   python-urlgrabber
 Requires:   python-dockerfile-parse
-Requires:   python-pycurl
 
 %description builder
 Builder plugin that extend Koji to communicate with OpenShift build system and

--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -30,7 +30,6 @@ import imp
 import time
 import traceback
 import dockerfile_parse
-import pycurl
 import signal
 
 import koji
@@ -562,13 +561,7 @@ class BuildContainerTask(BaseTaskHandler):
             except koji.ActionNotAllowed:
                 pass
         else:
-            # Make sure curl is initialized again otherwise connections via SSL
-            # fails with NSS error -8023 and curl_multi.info_read()
-            # returns error code 35 (SSL CONNECT failed).
-            # See http://permalink.gmane.org/gmane.comp.web.curl.library/38759
             self._osbs = None
-            self.logger.debug("Running pycurl global cleanup")
-            pycurl.global_cleanup()
 
             # Following retry code is here mainly to workaround bug which causes
             # connection drop while reading logs after about 5 minutes.

--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,7 @@ setup(
         'koji_containerbuild',
         'koji_containerbuild.plugins',
     ],
-    install_requires=[
-        "koji",
-        "osbs",
-        #"distutils",
-    ],
+    install_requires=[],
     scripts=['cli/koji-containerbuild'],
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -eux
+
+# Prepare env vars
+OS=${OS:="centos"}
+OS_VERSION=${OS_VERSION:="7"}
+PYTHON_VERSION=${PYTHON_VERSION:="2"}
+IMAGE="$OS:$OS_VERSION"
+# Pull fedora images from registry.fedoraproject.org
+if [[ $OS == "fedora" ]]; then
+  IMAGE="registry.fedoraproject.org/$IMAGE"
+fi
+
+CONTAINER_NAME="koji-containerbuild-$OS-$OS_VERSION-py$PYTHON_VERSION"
+RUN="docker exec -ti $CONTAINER_NAME"
+if [[ $OS == "fedora" ]]; then
+  if [[ $OS_VERSION == 25 && $PYTHON_VERSION == 2 ]]; then PIP_PKG="python-pip"; else PIP_PKG="python$PYTHON_VERSION-pip"; fi
+  PIP="pip$PYTHON_VERSION"
+  PKG="dnf"
+  PKG_EXTRA="dnf-plugins-core git-core python$PYTHON_VERSION-koji"
+  BUILDDEP="dnf builddep"
+  PYTHON="python$PYTHON_VERSION"
+  PYTEST="py.test-$PYTHON_VERSION"
+else
+  PIP_PKG="python-pip"
+  PIP="pip"
+  PKG="yum"
+  PKG_EXTRA="yum-utils epel-release git-core koji python-dockerfile-parse"
+  BUILDDEP="yum-builddep"
+  PYTHON="python"
+  PYTEST="py.test"
+fi
+# Create container if needed
+if [[ $(docker ps -q -f name=$CONTAINER_NAME | wc -l) -eq 0 ]]; then
+  docker run --name $CONTAINER_NAME -d -v $PWD:$PWD -w $PWD -ti $IMAGE sleep infinity
+fi
+
+# Install dependencies
+$RUN $PKG install -y $PKG_EXTRA
+$RUN $BUILDDEP -y koji-containerbuild.spec
+# Install package
+$RUN $PKG install -y $PIP_PKG
+if [[ $PYTHON_VERSION == 3 && $OS_VERSION == rawhide ]]; then
+  # https://fedoraproject.org/wiki/Changes/Making_sudo_pip_safe
+  $RUN mkdir -p /usr/local/lib/python3.6/site-packages/
+fi
+
+# Install other dependencies for tests
+
+# Install latest osbs-client by installing dependencies from the master branch
+# and running pip install with '--no-deps' to avoid compilation
+# This would also ensure all the deps are specified in the spec
+$RUN rm -rf /tmp/osbs-client
+$RUN git clone https://github.com/projectatomic/osbs-client /tmp/osbs-client
+$RUN $BUILDDEP -y /tmp/osbs-client/osbs-client.spec
+$RUN $PIP install --upgrade --no-deps --force-reinstall git+https://github.com/projectatomic/osbs-client
+$RUN $PYTHON setup.py install
+
+# Install packages for tests
+$RUN $PIP install -r tests/requirements.txt
+
+# Run tests
+$RUN $PIP install pytest-cov
+if [[ $OS != "fedora" ]]; then $RUN $PIP install -U pytest-cov; fi
+$RUN $PYTEST -vv tests --cov koji_containerbuild

--- a/test.sh
+++ b/test.sh
@@ -25,7 +25,7 @@ else
   PIP_PKG="python-pip"
   PIP="pip"
   PKG="yum"
-  PKG_EXTRA="yum-utils epel-release git-core koji python-dockerfile-parse"
+  PKG_EXTRA="yum-utils git-core koji python-dockerfile-parse"
   BUILDDEP="yum-builddep"
   PYTHON="python"
   PYTEST="py.test"
@@ -36,6 +36,7 @@ if [[ $(docker ps -q -f name=$CONTAINER_NAME | wc -l) -eq 0 ]]; then
 fi
 
 # Install dependencies
+if [[ $OS != "fedora" ]]; then $RUN $PKG install -y epel-release; fi
 $RUN $PKG install -y $PKG_EXTRA
 $RUN $BUILDDEP -y koji-containerbuild.spec
 # Install package

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,3 @@
+flexmock
+pytest
+pytest-capturelog


### PR DESCRIPTION
This PR is building a centos/fedora container and runs koji-containerbuild tests
and reports coverage data.

Note, that currently tests are py2 only, as there is no py3 koji version in repos 
yet.

In order to report results this repo should be added to Travis CI and Coveralls