### PR TITLE
Added docstring to CLI

### DIFF
--- a/koji_containerbuild/cli.py
+++ b/koji_containerbuild/cli.py
@@ -217,7 +217,9 @@ def handle_build(options, session, args, flatpak):
         return
 
 def handle_container_build(options, session, args):
+    "[build] Build a container"
     return handle_build(options, session, args, flatpak=False)
 
 def handle_flatpak_build(options, session, args):
+    "[build] Build a flatpak"
     return handle_build(options, session, args, flatpak=True)


### PR DESCRIPTION
CLI plugins are expected to have docstring, so they are properly
displayed be koji's builtin help command.

Related: https://pagure.io/koji/issue/644