### PR TITLE
Disallow use of yum_repourls with compose_ids

### DIFF
--- a/koji_containerbuild/cli.py
+++ b/koji_containerbuild/cli.py
@@ -130,7 +130,8 @@ def parse_arguments(options, args, flatpak):
                       help=_("Signing intent of the ODCS composes [default: %default]"),
                       default=None, dest='signing_intent')
     parser.add_option("--compose-id",
-                      help=_("ODCS composes used. May be used multiple times"),
+                      help=_("ODCS composes used. May be used multiple times. Cannot be"
+                             "used with signing-intent or repo-url"),
                       dest='compose_ids', action='append', metavar="COMPOSE_ID")
     if not flatpak:
         parser.add_option("--release",
@@ -148,6 +149,9 @@ def parse_arguments(options, args, flatpak):
 
     if build_opts.signing_intent and build_opts.compose_ids:
         parser.error(_("--signing-intent cannot be used with --compose-id"))
+
+    if build_opts.compose_ids and build_opts.yum_repourls:
+        parser.error(_("--compose-id cannot be used with --repo-url"))
 
     opts = {}
     if not build_opts.git_branch:

--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -513,6 +513,9 @@ class BuildContainerTask(BaseTaskHandler):
         if signing_intent and compose_ids:
             raise koji.BuildError("signing_intent used with compose_ids")
 
+        if compose_ids and yum_repourls:
+            raise koji.BuildError("compose_ids used with repo_url")
+
         create_build_args = {
             'git_uri': git_uri,
             'git_ref': scm.revision,

--- a/tests/test_kcb.py
+++ b/tests/test_kcb.py
@@ -810,7 +810,8 @@ class TestBuilder(object):
         ({}, False),
         ({'compose_ids': [1, 2]}, False),
         ({'signing_intent': 'intent1'}, False),
-        ({'compose_ids': [1, 2], 'signing_intent': 'intent1'}, True)
+        ({'compose_ids': [1, 2], 'signing_intent': 'intent1'}, True),
+        ({'compose_ids': [1, 2], 'yum_repourls': ['www.repo.com']}, True)
     ))
     def test_compose_ids_and_signing_intent(self, tmpdir, additional_args, raises):
         koji_task_id = 123


### PR DESCRIPTION
The parameters --repo-url and --compose-id cannot be used together.

Signed-off-by: Bret Fontecchio <bfontecc@redhat.com>