### PR TITLE
allow arch-override for isolated builds

### DIFF
--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -660,12 +660,12 @@ class BuildContainerTask(BaseTaskHandler):
         self.logger.debug('base archlist: %r' % archlist)
 
         override = self.opts.get('arch_override')
-        if self.opts.get('scratch') and override:
+        if (self.opts.get('isolated') or self.opts.get('scratch')) and override:
             # only honor override for scratch builds
             self.logger.debug('arch override: %s', override)
             archlist = override.split()
         elif override:
-            raise koji.BuildError("arch-override is only allowed for scratch builds")
+            raise koji.BuildError("arch-override is only allowed for isolated or scratch builds")
         archdict = {}
         for a in archlist:
             # Filter based on canonical arches for tag

--- a/koji_containerbuild/plugins/cli_containerbuild.py
+++ b/koji_containerbuild/plugins/cli_containerbuild.py
@@ -115,8 +115,8 @@ def parse_arguments(options, args, flatpak):
                        "are required"))
         assert False
 
-    if build_opts.arch_override and not build_opts.scratch:
-        parser.error(_("--arch-override is only allowed for --scratch builds"))
+    if build_opts.arch_override and not (build_opts.scratch or build_opts.isolated):
+        parser.error(_("--arch-override is only allowed for --scratch or --isolated builds"))
 
     if build_opts.signing_intent and build_opts.compose_ids:
         parser.error(_("--signing-intent cannot be used with --compose-id"))

--- a/tests/test_kcb.py
+++ b/tests/test_kcb.py
@@ -887,10 +887,18 @@ class TestBuilder(object):
         ({'scratch': True, 'arch_override': ''}, False),
         ({'scratch': False, 'arch_override': 'x86_64'}, True),
         ({'scratch': False, 'arch_override': ''}, False),
-        ({'isolated': True, 'arch_override': 'x86_64'}, True),
+        ({'isolated': True, 'arch_override': 'x86_64'}, False),
         ({'isolated': True, 'arch_override': ''}, False),
         ({'isolated': False, 'arch_override': 'x86_64'}, True),
         ({'isolated': False, 'arch_override': ''}, False),
+        ({'scratch': True, 'isolated': True, 'arch_override': 'x86_64'}, False),
+        ({'scratch': True, 'isolated': True, 'arch_override': ''}, False),
+        ({'scratch': False, 'isolated': True, 'arch_override': 'x86_64'}, False),
+        ({'scratch': False, 'isolated': True, 'arch_override': ''}, False),
+        ({'scratch': True, 'isolated': False, 'arch_override': 'x86_64'}, False),
+        ({'scratch': True, 'isolated': False, 'arch_override': ''}, False),
+        ({'scratch': False, 'isolated': False, 'arch_override': 'x86_64'}, True),
+        ({'scratch': False, 'isolated': False, 'arch_override': ''}, False),
     ))
     def test_arch_override(self, tmpdir, orchestrator, additional_args, raises):
         koji_task_id = 123


### PR DESCRIPTION
Allow arch-override to apply to isolated or scratch builds, and adjust test cases to match.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>