### PR TITLE
Add development requirements file

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,0 +1,2 @@
+git+https://github.com/projectatomic/osbs-client
+koji


### PR DESCRIPTION
I would add a requirements.txt file instead, but here we are installing osbs-client from git master, so appending the -devel seems to be the right thing to do here.