### PR TITLE
containerbuild: make sure the target exists before trying to tag it

### DIFF
--- a/koji_containerbuild/plugins/builder_containerbuild.py
+++ b/koji_containerbuild/plugins/builder_containerbuild.py
@@ -767,6 +767,9 @@ class BuildContainerTask(BaseTaskHandler):
 
         self.event_id = self.session.getLastEvent()['id']
         target_info = self.session.getBuildTarget(target, event=self.event_id)
+        if not target_info:
+            raise koji.BuildError("Target `%s` not found" % target)
+
         build_tag = target_info['build_tag']
         archlist = self.getArchList(build_tag)
 


### PR DESCRIPTION
after retrieving target_info, check that it exists and raise an error if it doesn't instead of getting a confusing error when attempting to tag it.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>