### PR TITLE
CI: Install coverall in install step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,9 @@ env:
     - OS=fedora
       OS_VERSION=29
       PYTHON_VERSION=2
-script:
+install:
  - pip install coveralls
+script:
  - ./test.sh
 after_success: coveralls
 notifications:

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 Koji containerbuild
 ===================
 
+.. image:: https://coveralls.io/repos/github/release-engineering/koji-containerbuild/badge.svg?branch=master
+   :target: https://coveralls.io/github/release-engineering/koji-containerbuild?branch=master
+
 This package extends Koji buildsystem with plugin which allows building
 containers via OpenShift buildsystem. Additionally it provides CLI tool to
 submit builds based on koji CLI.


### PR DESCRIPTION
Without having install step defined we are just waisting time with
install default autinstall of requirements.txt we don't need

Signed-off-by: Martin Bašti <mbasti@redhat.com>